### PR TITLE
Change from python_package to module_name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,4 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.dagster]
-python_package = "dagster_etl_enrich_demo"
+module_name = "dagster_etl_enrich_demo"


### PR DESCRIPTION
With the latest release of Dagster we switch from python_package to module_name. Switching to module_name.